### PR TITLE
Optimize 'fold', document blocking caveat of 'duplicate', and fix race in 'receive'

### DIFF
--- a/src/Control/Concurrent/Chan/Split/Implementation.hs
+++ b/src/Control/Concurrent/Chan/Split/Implementation.hs
@@ -98,7 +98,7 @@ send (SendPort s) a = do
 
 -- | A right fold over a receiver,  a generalization of @getChanContents@
 --   where @getChanContents = fold (:)@. Note that the type of 'fold'
---   implies that the folding function needs to be sufficienctly non-strict,
+--   implies that the folding function needs to be sufficiently non-strict,
 --   otherwise the result cannot be productive.
 
 fold :: (a -> b -> b) -> ReceivePort a -> IO b

--- a/src/Control/Concurrent/Chan/Split/Implementation.hs
+++ b/src/Control/Concurrent/Chan/Split/Implementation.hs
@@ -72,6 +72,9 @@ listen   (SendPort a) =  ReceivePort `fmap` withMVar a newMVar
 --   @ReceivePort@.  These two ports will receive the same messages.
 --   Any messages in the channel that have not been consumed by the
 --   existing port will also appear in the new port.
+--
+--   Warning: this will block if another thread is blocked on 'receive' with
+--   the same 'ReceivePort'.
 
 duplicate :: ReceivePort a  -> IO (ReceivePort a)
 duplicate   (ReceivePort a) =  ReceivePort `fmap` withMVar a newMVar
@@ -100,6 +103,11 @@ send (SendPort s) a = do
 --   where @getChanContents = fold (:)@. Note that the type of 'fold'
 --   implies that the folding function needs to be sufficiently non-strict,
 --   otherwise the result cannot be productive.
+--
+--   Normally, this will return immediately; forcing the returned value will
+--   wait for the next item using lazy IO.  However, 'fold' has the same caveat
+--   as 'duplicate': it will block if other threads are blocked on 'receive'
+--   with the same 'ReceivePort'.
 
 fold :: (a -> b -> b) -> ReceivePort a -> IO b
 fold f recv = unsafeFold f =<< duplicate recv

--- a/src/Control/Concurrent/Chan/Split/Internal.hs
+++ b/src/Control/Concurrent/Chan/Split/Internal.hs
@@ -27,6 +27,7 @@ module Control.Concurrent.Chan.Split.Internal
      , ReceivePort(..)
      , List
      , Item(..)
+     , foldList
      ) where
 
 import Control.Concurrent.Chan.Split.Implementation


### PR DESCRIPTION
Please see the commit messages.  In particular, `duplicate` has the same [blocking caveat](http://hackage.haskell.org/trac/ghc/ticket/4154) that bit [isEmptyChan](http://hackage.haskell.org/packages/archive/base/latest/doc/html/Control-Concurrent-Chan.html#v:isEmptyChan) and [unGetChan](http://hackage.haskell.org/packages/archive/base/latest/doc/html/Control-Concurrent-Chan.html#v:unGetChan).

Differences between `unsafeFold` and `fold`:
- `unsafeFold` is _less_ efficient than `fold`; see commit 51871dd
- `unsafeFold` can be used to make multiple threads fight over a single channel, useful for sharing jobs among threads.
- `unsafeFold` breaks referential transparency under base < 4.6 due to `unsafeInterleaveIO` duplicating the computation; see [GHC ticket 5859](http://hackage.haskell.org/trac/ghc/ticket/5859).  Regular `fold` does not have this problem because its interleaved computation does not leave side effects in its wake.
